### PR TITLE
Do not depend on defmt if the defmt feature is disabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ keywords = ["device_driver", "IMU", "icm-20948"]
 
 [features]
 default = ["defmt"]
-defmt = []
+defmt = ["dep:defmt"]
 
 [dependencies]
 embedded-hal = "0.2.7"
-defmt = "0.3.0"
+defmt = { version = "0.3.0", optional = true }
 defmt-rtt = "0.3.0"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 

--- a/src/icm20948.rs
+++ b/src/icm20948.rs
@@ -1,7 +1,8 @@
 // Copyright (c) 2022, Zachary D. Olkin.
 // This code is provided under the MIT license.
 
-use defmt::{Format, Formatter};
+#[cfg(feature = "defmt")]
+use defmt::{Formatter, Format};
 
 /// The i2c module holds all of the driver implementations when using an I2C bus to communicate with the device
 pub mod i2c;
@@ -30,7 +31,8 @@ const REG_BANK_2: u8 = 0x20;
 //const REG_BANK_3: u8 = 0x30;
 
 /// States of the accelerometer: On or Off
-#[derive(PartialEq, Format)]
+#[derive(PartialEq)]
+#[cfg_attr(feature = "defmt", derive(Format))]
 pub enum AccStates {
     /// On
     AccOn,
@@ -39,7 +41,8 @@ pub enum AccStates {
 }
 
 /// States of the gyro: On or Off
-#[derive(PartialEq, Format)]
+#[derive(PartialEq)]
+#[cfg_attr(feature = "defmt", derive(Format))]
 pub enum GyroStates {
     /// On
     GyroOn,
@@ -48,7 +51,8 @@ pub enum GyroStates {
 }
 
 /// States of the magnetometer: On or Off
-#[derive(PartialEq, Format)]
+#[derive(PartialEq)]
+#[cfg_attr(feature = "defmt", derive(Format))]
 pub enum MagStates {
     /// On
     MagOn,

--- a/src/icm20948/i2c.rs
+++ b/src/icm20948/i2c.rs
@@ -16,6 +16,8 @@ use crate::icm20948::{
     GYRO_SEN_3, INT_ENABLED, INT_NOT_ENABLED, WRITE_REG,
 };
 use crate::icm20948::{REG_BANK_0, REG_BANK_2};
+
+#[cfg(feature = "defmt")]
 use defmt::{Format, Formatter};
 
 use embedded_hal::blocking::i2c;
@@ -627,6 +629,7 @@ where
     }
 }
 
+#[cfg(feature = "defmt")]
 impl<BUS> Format for IcmImu<BUS> {
     fn format(&self, fmt: Formatter) {
         defmt::write!(fmt, "ICM-20948 IMU")

--- a/src/icm20948/spi.rs
+++ b/src/icm20948/spi.rs
@@ -16,6 +16,8 @@ use crate::icm20948::{
     GYRO_SEN_3, INT_ENABLED, INT_NOT_ENABLED, READ_REG, WRITE_REG,
 };
 use crate::icm20948::{REG_BANK_0, REG_BANK_2};
+
+#[cfg(feature = "defmt")]
 use defmt::{Format, Formatter};
 
 use embedded_hal::{self as hal, blocking::spi};
@@ -129,6 +131,7 @@ where
         self.cs.set_high().ok();
 
         self.acc_en = AccOn;
+        #[cfg(feature = "defmt")]
         defmt::trace!("Accelerometer: On");
 
         Ok(())
@@ -147,6 +150,7 @@ where
         self.cs.set_high().ok();
 
         self.acc_en = AccOff;
+        #[cfg(feature = "defmt")]
         defmt::trace!("Accelerometer: Off");
 
         Ok(())
@@ -166,6 +170,7 @@ where
         self.cs.set_high().ok();
 
         self.gyro_en = GyroOn;
+        #[cfg(feature = "defmt")]
         defmt::trace!("Gyro: On");
 
         Ok(())
@@ -184,6 +189,7 @@ where
         self.cs.set_high().ok();
 
         self.gyro_en = GyroOff;
+        #[cfg(feature = "defmt")]
         defmt::trace!("Gyro: Off");
 
         Ok(())
@@ -709,6 +715,7 @@ where
     }
 }
 
+#[cfg(feature = "defmt")]
 impl<BUS, PIN> Format for IcmImu<BUS, PIN> {
     fn format(&self, fmt: Formatter) {
         defmt::write!(fmt, "ICM-20948 IMU")


### PR DESCRIPTION
I made defmt an optional dependency that's only added when the defmt feature is enabled. Additionally, I added conditional compilation flags to every usage of demft in order to prevent compilation errors.

Now, compilation with the `--no-default-features` flag will behave as expected and no longer compile and link defmt.