### PR TITLE
Remove panic_probe dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,13 @@ defmt = []
 embedded-hal = "0.2.7"
 defmt = "0.3.0"
 defmt-rtt = "0.3.0"
-panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 
 [dev-dependencies]
 cortex-m-rtic = "1.1"
 systick-monotonic = "1.0.0"
 cortex-m-rt = "0.7.0"
 cortex-m = "0.7"
-
-
+panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 
 [dev-dependencies.stm32h7xx-hal]
 version = "0.12.2"

--- a/examples/basic_i2c.rs
+++ b/examples/basic_i2c.rs
@@ -9,6 +9,7 @@ use cortex_m_rt::entry;
 use icm20948_driver::icm20948;
 use icm20948_driver::icm20948::i2c as imu_i2c;
 use stm32h7xx_hal::{pac, prelude::*};
+use panic_probe as _;
 
 #[entry]
 fn main() -> ! {

--- a/examples/basic_spi.rs
+++ b/examples/basic_spi.rs
@@ -9,6 +9,7 @@ use cortex_m_rt::entry;
 use icm20948_driver::icm20948;
 use icm20948_driver::icm20948::spi as imu_spi;
 use stm32h7xx_hal::{pac, prelude::*, spi};
+use panic_probe as _;
 
 #[entry]
 fn main() -> ! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,6 @@
 #![no_main]
 
 use defmt_rtt as _; // global logger
-use panic_probe as _;
 
 /// Main module that holds the SPI and I2C sub modules.
 /// Also holds many enums and constants shared between SPI and I2C


### PR DESCRIPTION
The inclusion of `panic_probe` causes this crate to conflict with any project that includes a different panic crate. I don't think it's appropriate for a driver crate to specify panic behavior.

I was not able to verify that the examples still compile after this change (thanks to a linker error that I couldn't bother to fix), so please verify that they still work as expected before merging this branch.